### PR TITLE
Optimize extending cache with redis-tags store

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -3,6 +3,7 @@
 namespace ByErikas\CacheTags;
 
 use ByErikas\CacheTags\Cache\Store;
+use Illuminate\Contracts\Cache\Factory;
 use Illuminate\Support\ServiceProvider as IlluminateServiceProvider;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Facades\Cache;
@@ -14,8 +15,8 @@ class ServiceProvider extends IlluminateServiceProvider
      */
     public function register()
     {
-        $this->app->afterResolving("cache", function () {
-            Cache::extend("redis-tags", function (Application $app) {
+        $this->app->afterResolving("cache", static function (Factory $factory) {
+            $factory->extend("redis-tags", static function (Application $app) {
                 return Cache::repository(new Store($app["redis"], $app["config"]["cache.prefix"], $app["config"]["cache.stores.redis"]["connection"]));
             });
         });

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -6,7 +6,6 @@ use ByErikas\CacheTags\Cache\Store;
 use Illuminate\Contracts\Cache\Factory;
 use Illuminate\Support\ServiceProvider as IlluminateServiceProvider;
 use Illuminate\Contracts\Foundation\Application;
-use Illuminate\Support\Facades\Cache;
 
 class ServiceProvider extends IlluminateServiceProvider
 {
@@ -16,8 +15,10 @@ class ServiceProvider extends IlluminateServiceProvider
     public function register()
     {
         $this->app->afterResolving("cache", static function (Factory $factory) {
-            $factory->extend("redis-tags", static function (Application $app) {
-                return Cache::repository(new Store($app["redis"], $app["config"]["cache.prefix"], $app["config"]["cache.stores.redis"]["connection"]));
+            $factory->extend("redis-tags", function (Application $app) {
+                /** @var Factory $this */
+
+                return $this->repository(new Store($app["redis"], $app["config"]["cache.prefix"], $app["config"]["cache.stores.redis"]["connection"]));
             });
         });
     }


### PR DESCRIPTION
This PR optimizes extending the cache with redis-tags store, as using the `Cache` facade is an unnecessary overhead, since the instance being resolved is passed to the `afterResolving` callback & the custom creator callable is bound to the factory.