### PR TITLE
Fix: cache lock_connection

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -17,8 +17,13 @@ class ServiceProvider extends IlluminateServiceProvider
         $this->app->afterResolving("cache", static function (Factory $factory) {
             $factory->extend("redis-tags", function (Application $app, array $config) {
                 /** @var Factory $this */
+                $connection = $config['connection'] ?? $app["config"]["cache.stores.redis"]["connection"];
 
-                return $this->repository(new Store($app["redis"], $app["config"]["cache.prefix"], $config['connection'] ?? $app["config"]["cache.stores.redis"]["connection"]));
+                $store = new Store($app["redis"], $app["config"]["cache.prefix"], $connection);
+
+                $store->setLockConnection($config['lock_connection'] ?? $connection);
+
+                return $this->repository($store);
             });
         });
     }

--- a/tests/Unit/CacheTest.php
+++ b/tests/Unit/CacheTest.php
@@ -419,3 +419,25 @@ it("#31 can check if an item is missing from the cache (different store)", funct
     expect($cache->missing($key))->toBeFalse();
     expect($cache->missing($key . "_missing"))->toBeTrue();
 });
+
+it("releases an atomic lock so it is re-acquirable before its ttl", function () {
+    $cache = $this->cache();
+    $key = (string) $this->key();
+
+    expect($cache->lock($key, 30)->get(fn () => "first"))->toBe("first");
+    expect($cache->lock($key, 30)->get(fn () => "second"))->toBe("second");
+});
+
+it("runs atomic locks on the configured lock_connection", function () {
+    config()->set("database.redis.locks", config("database.redis.default"));
+    config()->set("cache.stores.split_lock", [
+        "driver" => "redis-tags",
+        "connection" => "default",
+        "lock_connection" => "locks",
+    ]);
+
+    $store = $this->cache("split_lock")->getStore();
+
+    expect($store->lockConnection()->getName())->toBe("locks")
+        ->and($store->lockConnection()->getName())->not->toBe($store->connection()->getName());
+});


### PR DESCRIPTION
The `redis-tags` store builds its `Store` directly and never calls `setLockConnection()`, so a `lock_connection` configured on the store is silently ignored — `Cache::lock()` always runs on the data `connection`.

Laravel's own `CacheManager::createRedisDriver()` forwards `lock_connection`:

```php
$store = new RedisStore($redis, $this->getPrefix($config), $connection);

return $this->repository(
    $store->setLockConnection($config['lock_connection'] ?? $connection),
    $config
);
```

This package's provider drops that step, so the documented Laravel option has no effect when using the `redis-tags` driver.

It's common to run atomic locks on a different Redis connection than cached values. A concrete case: keeping cache values on an **igbinary-serialized** connection (smaller payloads) while routing locks to a **serializer-free** connection. Today that's impossible with `redis-tags` - locks inherit the cache connection regardless of `lock_connection`.

## Fix

Resolve the connection once, build the store, then forward `lock_connection` (defaulting to the data connection), mirroring Laravel core:

```php
$connection = $config['connection'] ?? $app["config"]["cache.stores.redis"]["connection"];

$store = new Store($app["redis"], $app["config"]["cache.prefix"], $connection);

$store->setLockConnection($config['lock_connection'] ?? $connection);

return $this->repository($store);
```

## Backward compatibility

None broken. When `lock_connection` is absent it falls back to `connection`, which is the current behavior - so existing setups are unaffected.